### PR TITLE
catch error message from hipchat-api response

### DIFF
--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -52,7 +52,7 @@ module Fluent
           send_message(record) if record['message']
           set_topic(record) if record['topic']
         rescue => e
-          $log.error("HipChat Error: #{e} / #{e.message}")
+          $log.error("HipChat Error:", :error_class => e.class, :error => e.message)
         end
       end
     end
@@ -68,14 +68,16 @@ module Fluent
       end
       color = COLORS.include?(record['color']) ? record['color'] : @default_color
       message_format = FORMAT.include?(record['format']) ? record['format'] : @default_format
-      @hipchat.rooms_message(room, from, message, notify, color, message_format)
+      response = @hipchat.rooms_message(room, from, message, notify, color, message_format)
+      raise StandardError, response['error']['message'].to_s if defined?(response['error']['message'])
     end
 
     def set_topic(record)
       room = record['room'] || @default_room
       from = record['from'] || @default_from
       topic = record['topic']
-      @hipchat.rooms_topic(room, topic, from)
+      response = @hipchat.rooms_topic(room, topic, from)
+      raise StandardError, response['error']['message'].to_s if defined?(response['error']['message'])
     end
   end
 end

--- a/test/plugin/out_hipchat.rb
+++ b/test/plugin/out_hipchat.rb
@@ -70,6 +70,26 @@ class HipchatOutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_set_topic_response_error
+    d = create_driver
+    stub(d.instance.hipchat).rooms_topic('testroom', 'foo', 'testuser') {
+      {'error' => { 'code' => 400, 'type' => 'Bad Request', 'message' => 'Topic body must be between 1 and 250 characters.' } }
+    }
+    stub($log).error("HipChat Error:", :error_class => StandardError, :error => 'Topic body must be between 1 and 250 characters.')
+    d.emit({'topic' => 'foo'})
+    d.run
+  end
+
+  def test_send_message_response_error
+    d = create_driver
+    stub(d.instance.hipchat).rooms_message('testroom', '<abc>', 'foo', 0, 'yellow', 'html') {
+      {'error' => { 'code' => 400, 'type' => 'Bad Request', 'message' => 'From name may not contain HTML.' } }
+    }
+    stub($log).error("HipChat Error:", :error_class => StandardError, :error => 'From name may not contain HTML.')
+    d.emit({'from' => '<abc>', 'message' => 'foo'})
+    d.run
+  end
+
   def test_color_validate
     d = create_driver
     stub(d.instance.hipchat).rooms_message('testroom', 'testuser', 'foo', 0, 'yellow', 'html')


### PR DESCRIPTION
I have add a new feature for this plugin.
It comes to catch and raise message on response error such as these error below.
- too log message
- invalid from name
### example of error behavior

```
2014-02-19 12:03:18 +0900 hipchat.message: {"from":"<abc>","message":"test"}
2014-02-19 12:03:21 +0900 [error]: HipChat Error: error_class=StandardError error="From name may not contain HTML."
```

```
2014-02-19 12:03:27 +0900 hipchat.message: {"from":"user@example.com","message":"test"}
2014-02-19 12:03:29 +0900 [error]: HipChat Error: error_class=StandardError error="From name must be between 1 and 15 characters."
```
