### PR TITLE
HitChat request timeout setting

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,7 @@
       default_color yellow
       default_notify 0
       default_format html
+      default_timeout 3  # HipChat API Request Timeout Seconds (default 3)
       
       # proxy settings
       # http_proxy_host localhost

--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -11,6 +11,7 @@ module Fluent
     config_param :default_from, :string, :default => nil
     config_param :default_notify, :bool, :default => nil
     config_param :default_format, :string, :default => nil
+    config_param :default_timeout, :time, :default => nil
     config_param :http_proxy_host, :string, :default => nil
     config_param :http_proxy_port, :integer, :default => nil
     config_param :http_proxy_user, :string, :default => nil
@@ -33,6 +34,7 @@ module Fluent
       @default_notify = conf['default_notify'] || 0
       @default_color = conf['default_color'] || 'yellow'
       @default_format = conf['default_format'] || 'html'
+      @default_timeout = conf['default_timeout']
       if conf['http_proxy_host']
         HipChat::API.http_proxy(
           conf['http_proxy_host'],
@@ -68,6 +70,7 @@ module Fluent
       end
       color = COLORS.include?(record['color']) ? record['color'] : @default_color
       message_format = FORMAT.include?(record['format']) ? record['format'] : @default_format
+      @hipchat.set_timeout(@default_timeout.to_i) unless @default_timeout.nil?
       response = @hipchat.rooms_message(room, from, message, notify, color, message_format)
       raise StandardError, response['error']['message'].to_s if defined?(response['error']['message'])
     end


### PR DESCRIPTION
The default is 3 seconds. 
However, an error may occur in 3 seconds in my environment.

see https://github.com/czarneckid/hipchat-api/blob/master/lib/hipchat-api.rb#L9
