### PR TITLE
add 'mention_to' setting

### DIFF
--- a/lib/fluent/plugin/out_hipchat.rb
+++ b/lib/fluent/plugin/out_hipchat.rb
@@ -18,6 +18,7 @@ module Fluent
     config_param :http_proxy_user, :string, :default => nil
     config_param :http_proxy_pass, :string, :default => nil
     config_param :flush_interval, :time, :default => 1
+    config_param :mention_to, :string, :default => nil
 
     attr_reader :hipchat
 
@@ -36,6 +37,7 @@ module Fluent
       @default_color = conf['default_color'] || 'yellow'
       @default_format = conf['default_format'] || 'html'
       @default_timeout = conf['default_timeout']
+      @mention_to = conf['mention_to']
       if conf['http_proxy_host']
         HipChat::API.http_proxy(
           conf['http_proxy_host'],
@@ -64,6 +66,7 @@ module Fluent
       room = record['room'] || @default_room
       from = record['from'] || @default_from
       message = record[@key_name]
+      message = @mention_to + ' ' + message unless @mention_to.nil?
       if record['notify'].nil?
         notify = @default_notify
       else

--- a/test/plugin/out_hipchat.rb
+++ b/test/plugin/out_hipchat.rb
@@ -50,6 +50,16 @@ class HipchatOutputTest < Test::Unit::TestCase
     d.run
   end
 
+  def test_set_mention_to
+    d = create_driver(<<-EOF)
+                      type hipchat
+                      api_token xxx
+                      mention_to @here
+                      EOF
+    d.emit({'message' => 'foo'})
+    d.run
+  end
+
   def test_message
     d = create_driver
     stub(d.instance.hipchat).rooms_message('testroom', 'testuser', 'foo', 0, 'red', 'html')


### PR DESCRIPTION
I Use this plugin with [fluent-plugin-ping-message's PingMessageCheckerOutput](https://github.com/tagomoris/fluent-plugin-ping-message#pingmessagecheckeroutput).

But PingMessageCheckerOutput is can not modify the message.

I want to setting mention feature with this plugin.
